### PR TITLE
feat: add browser tab titles to all pages using document.title

### DIFF
--- a/client/src/pages/Authentication.jsx
+++ b/client/src/pages/Authentication.jsx
@@ -29,6 +29,11 @@ export default function Authentication() {
   const [resetSent, setResetSent] = useState(false);
   const [visible, setVisible] = useState(false);
 
+  // custom title for login page 
+  useEffect(() => {
+    document.title = "Login - FitMart";
+  }, []);
+
   useEffect(() => {
     setTimeout(() => setVisible(true), 80);
   }, []);

--- a/client/src/pages/Checkout.jsx
+++ b/client/src/pages/Checkout.jsx
@@ -12,6 +12,11 @@ export default function Checkout() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
 
+  // custom title for checkout page 
+  useEffect(() => {
+    document.title = "My Cart - FitMart";
+  }, []);
+
   useEffect(() => {
     // onAuthStateChanged fires once on mount with the current user (or null).
     // This is more reliable than auth.currentUser which can be null on first render

--- a/client/src/pages/HomePage.jsx
+++ b/client/src/pages/HomePage.jsx
@@ -140,8 +140,8 @@ function ProductCard({ product, onAdd, cartItems = [], updateQty }) {
             <button
               onClick={handleAdd}
               className={`text-xs px-4 py-2 rounded-full transition-all duration-200 ${added
-                  ? "bg-stone-900 text-white"
-                  : "border border-stone-300 text-stone-700 hover:bg-stone-900 hover:text-white hover:border-stone-900"
+                ? "bg-stone-900 text-white"
+                : "border border-stone-300 text-stone-700 hover:bg-stone-900 hover:text-white hover:border-stone-900"
                 }`}
             >
               {added ? "Added ✓" : "Add to cart"}
@@ -166,6 +166,11 @@ export default function HomePage() {
   const [products, setProducts] = useState([]);
   const [backendError, setBackendError] = useState(false);
   const [loading, setLoading] = useState(true);
+
+  // custom titles for home page 
+  useEffect(() => {
+    document.title = "FitMart - Fitness & Nutrition Store";
+  }, []);
 
   useEffect(() => {
     setTimeout(() => setVisible(true), 80);
@@ -424,8 +429,8 @@ export default function HomePage() {
                   key={c.value}
                   onClick={() => setActiveCategory(c.value)}
                   className={`text-xs px-4 py-2 rounded-full transition-all ${activeCategory === c.value
-                      ? "bg-stone-900 text-white"
-                      : "bg-white border border-stone-200 text-stone-600 hover:bg-stone-50"
+                    ? "bg-stone-900 text-white"
+                    : "bg-white border border-stone-200 text-stone-600 hover:bg-stone-50"
                     }`}
                 >
                   {c.name}
@@ -462,8 +467,8 @@ export default function HomePage() {
                   {plan.desc}
                 </p>
                 <button className={`text-xs py-2.5 rounded-full transition-colors mt-1 ${i === 0
-                    ? "bg-white text-stone-900 hover:bg-stone-100"
-                    : "border border-stone-300 text-stone-700 hover:bg-stone-50"
+                  ? "bg-white text-stone-900 hover:bg-stone-100"
+                  : "border border-stone-300 text-stone-700 hover:bg-stone-50"
                   }`}>
                   View Plan →
                 </button>

--- a/client/src/pages/LandingPage.jsx
+++ b/client/src/pages/LandingPage.jsx
@@ -62,6 +62,11 @@ export default function LandingPage() {
   const programsRef = useRef(null);
   const aboutRef = useRef(null);
 
+  // custom titles for landing page
+  useEffect(() => {
+    document.title = "FitMart - Fitness & Nutrition Store";
+  }, []);
+
   useEffect(() => {
     setTimeout(() => setVisible(true), 100);
     const onScroll = () => setScrollY(window.scrollY);

--- a/client/src/pages/PaymentPage.jsx
+++ b/client/src/pages/PaymentPage.jsx
@@ -33,6 +33,11 @@ export default function PaymentPage() {
   const [bypassing, setBypassing] = useState(false);
   const [error, setError] = useState(null);
 
+  // custom title for Paymentpage 
+  useEffect(() => {
+    document.title = "My Orders - FitMart";
+  }, []);
+
   const { items = [], total = 0 } = location.state || {};
   useEffect(() => {
     if (!items.length) navigate("/checkout");

--- a/client/src/pages/ProductConfirmation.jsx
+++ b/client/src/pages/ProductConfirmation.jsx
@@ -11,6 +11,11 @@ export default function ProductConfirmation() {
 
   const { items = [], total = 0, paymentId = "" } = location.state || {};
 
+  // custom title for product confirm page 
+  useEffect(() => {
+    document.title = "FitMart";
+  }, []);
+
   // Order date — set once on mount
   const orderDate = useRef(
     new Date().toLocaleDateString("en-IN", {


### PR DESCRIPTION
## 📋 What does this PR do?

This PR adds meaningful browser tab titles to all pages using `document.title` inside `useEffect`. Each page now has a unique and descriptive title for better user experience and basic SEO.

## 🔗 Related Issue

Closes #19

## 🧪 How was this tested?

* Ran the application locally using `npm run dev`
* Navigated through all pages (Home, Login, Cart, Orders, etc.)
* Verified that the browser tab title updates correctly on each page

## 📸 Screenshots (if UI changes)

N/A (No UI changes were made)

## ✅ Checklist

* [x] I've read the CONTRIBUTING guide
* [x] My code follows the project's style guidelines
* [x] I've tested my changes locally
* [x] I've linked the related issue
* [x] I haven't introduced any new secrets or API keys
