### PR TITLE
feat: enhance order processing with paymentId to prevent duplicates

### DIFF
--- a/server/models/Order.js
+++ b/server/models/Order.js
@@ -12,9 +12,24 @@ const OrderItemSchema = new mongoose.Schema(
 const OrderSchema = new mongoose.Schema(
   {
     userId: { type: String, required: true, index: true },
+
     items: { type: [OrderItemSchema], required: true },
+
     total: { type: Number, required: true },
-    status: { type: String, default: 'created' },
+
+    status: {
+      type: String,
+      enum: ['created', 'paid', 'failed'], // 👈 better control
+      default: 'created'
+    },
+
+    // ✅ ADD THIS
+    paymentId: {
+      type: String,
+      unique: true,
+      sparse: true // allows null values safely
+    }
+
   },
   { timestamps: true }
 );

--- a/server/routes/payment.js
+++ b/server/routes/payment.js
@@ -1,5 +1,6 @@
 // server/routes/payment.js
 
+const axios = require("axios");
 const express = require("express");
 const Razorpay = require("razorpay");
 const crypto = require("crypto");
@@ -65,6 +66,7 @@ router.post("/create-order", async (req, res) => {
 // POST /verify-payment
 // Body: { razorpay_order_id, razorpay_payment_id, razorpay_signature, userId }
 // ─────────────────────────────────────────────────────────────────────────────
+
 router.post("/verify-payment", async (req, res) => {
   try {
     const { razorpay_order_id, razorpay_payment_id, razorpay_signature, userId } = req.body;
@@ -80,7 +82,27 @@ router.post("/verify-payment", async (req, res) => {
     if (expected !== razorpay_signature)
       return res.status(400).json({ error: "Signature mismatch — payment not verified" });
 
-    res.json({ success: true, paymentId: razorpay_payment_id });
+    // ✅ STEP 1: Prevent duplicate orders
+    const Order = require("../models/Order");
+    const existingOrder = await Order.findOne({ paymentId: razorpay_payment_id });
+
+    if (existingOrder) {
+      return res.json({ success: true, message: "Order already created" });
+    }
+
+    // ✅ STEP 2: Create order using existing route logic
+    const orderResponse = await axios.post("http://localhost:5000/api/orders", {
+      userId
+    });
+
+    // ✅ STEP 3: Attach paymentId to order
+    await Order.findByIdAndUpdate(orderResponse.data._id, {
+      paymentId: razorpay_payment_id,
+      status: "paid"
+    });
+
+    res.json({ success: true, order: orderResponse.data });
+
   } catch (err) {
     console.error("verify-payment error:", err);
     res.status(500).json({ error: err.message });
@@ -112,14 +134,35 @@ router.post("/clear-cart", async (req, res) => {
 // Body: { userId }
 // Skips Razorpay entirely, fakes a payment ID, clears cart, returns success.
 // ─────────────────────────────────────────────────────────────────────────────
+
 router.post("/demo-success", async (req, res) => {
   try {
     const { userId } = req.body;
     if (!userId) return res.status(400).json({ error: "userId is required" });
 
     const fakePaymentId = `pay_DEMO_${Date.now()}`;
-    await releaseAndClearCart(userId);   // same cleanup as real payment
-    res.json({ success: true, paymentId: fakePaymentId });
+
+    const Order = require("../models/Order");
+
+    // prevent duplicate
+    const existingOrder = await Order.findOne({ paymentId: fakePaymentId });
+    if (existingOrder) {
+      return res.json({ success: true, message: "Order already exists" });
+    }
+
+    // create order
+    const orderResponse = await axios.post("http://localhost:5000/api/orders", {
+      userId
+    });
+
+    // attach payment id
+    await Order.findByIdAndUpdate(orderResponse.data._id, {
+      paymentId: fakePaymentId,
+      status: "paid"
+    });
+
+    res.json({ success: true, order: orderResponse.data });
+
   } catch (err) {
     console.error("demo-success error:", err);
     res.status(500).json({ error: err.message });


### PR DESCRIPTION
## 📋 What does this PR do?

Implements order persistence after successful payment verification.
Orders are now created in MongoDB only after payment is verified (Razorpay or demo flow), including price snapshotting, stock updates, and cart clearance.

---

## 🔗 Related Issue

Closes #13

---

## 🧪 How was this tested?

* Tested `/demo-success` endpoint:

  * Order is created successfully in MongoDB
  * Cart is cleared after order creation
  * Payment ID is attached to the order
* Tested `/verify-payment` endpoint:

  * Valid signature → order created and marked as `paid`
  * Duplicate request → no duplicate order created
* Verified:

  * Items include correct `productId`, `quantity`, and price snapshot
  * Total amount calculation is accurate
  * Stock and reserved values are updated correctly

---

## 📸 Screenshots (if UI changes)

N/A (No UI changes)

---

## ✅ Checklist

* [x] I've read the CONTRIBUTING guide
* [x] My code follows the project's style guidelines
* [x] I've tested my changes locally
* [x] I've linked the related issue
* [x] I haven't introduced any new secrets or API keys