### PR TITLE
refactor: add Escape key close behavior for CartDrawer accessibility

### DIFF
--- a/client/src/components/CartDrawer.jsx
+++ b/client/src/components/CartDrawer.jsx
@@ -1,8 +1,18 @@
 // src/components/CartDrawer.jsx
+import { useEffect } from "react";
 import { fmt } from "../utils/formatters";
 import { Link } from "react-router-dom";
 
 function CartDrawer({ isOpen, onClose, cart, cartCount, cartTotal, updateQty, removeFromCart }) {
+  // Close the drawer when the Escape key is pressed
+  useEffect(() => {
+    const handleKeyDown = (e) => {
+      if (e.key === "Escape" && isOpen) onClose();
+    };
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [isOpen, onClose]);
+
   return (
     <>
       {/* Overlay */}


### PR DESCRIPTION
Closes #37

## What

Added a `useEffect` hook to `CartDrawer.jsx` that listens for the `keydown` event and calls `onClose()` when `Escape` is pressed while the drawer is open.

## Why

Keyboard users had no way to dismiss the cart. Pressing `Escape` to close drawers and modals is a standard browser accessibility expectation (ARIA APG pattern).

## Changes

`client/src/components/CartDrawer.jsx`
- Import `useEffect` from React
- Add effect that attaches/removes a `keydown` listener scoped to `[isOpen, onClose]`

## Acceptance criteria
- [x] Pressing `Escape` while the cart is open closes the drawer
- [x] Event listener is cleaned up on unmount and when `isOpen` changes
- [x] Overlay click still works as before
- [x] No console errors when toggling the drawer repeatedly