### PR TITLE
fix: move /low-stock route before /:id in products routes

### DIFF
--- a/server/routes/products.js
+++ b/server/routes/products.js
@@ -12,6 +12,20 @@ router.get('/', async (req, res) => {
   }
 });
 
+// GET /api/products/low-stock - get products with low stock
+const LOW_STOCK_THRESHOLD = 5;
+
+router.get('/low-stock', async (req, res) => {
+  try {
+    // only check products where stock is not null
+    const products = await Product.find({ stock: { $ne: null } });
+    const lowStock = products.filter(p => (p.stock - p.reserved) < LOW_STOCK_THRESHOLD);
+    res.json(lowStock);
+  } catch (err) {
+    res.status(500).json({ error: 'Server error' });
+  }
+});
+
 // GET /api/products/:id - get product by productId
 router.get('/:id', async (req, res) => {
   try {
@@ -54,19 +68,6 @@ router.delete('/:id', async (req, res) => {
     const deleted = await Product.findOneAndDelete({ productId: Number(req.params.id) });
     if (!deleted) return res.status(404).json({ error: 'Product not found' });
     res.json({ success: true });
-  } catch (err) {
-    res.status(500).json({ error: 'Server error' });
-  }
-});
-// GET /api/products/low-stock - get products with low stock
-const LOW_STOCK_THRESHOLD = 5;
-
-router.get('/low-stock', async (req, res) => {
-  try {
-    // only check products where stock is not null
-    const products = await Product.find({ stock: { $ne: null } });
-    const lowStock = products.filter(p => (p.stock - p.reserved) < LOW_STOCK_THRESHOLD);
-    res.json(lowStock);
   } catch (err) {
     res.status(500).json({ error: 'Server error' });
   }


### PR DESCRIPTION
## Summary
- Moved the `/low-stock` route definition above the `/:id` route in `server/routes/products.js`
- Express matches routes in declaration order, so `/api/products/low-stock` was incorrectly caught by `/:id` (treating "low-stock" as an id)
- No logic changes — just reordered the route declarations

Closes #35

## Test plan
- [ ] `GET /api/products/low-stock` returns a JSON array of low-stock products (not a "product not found" error)
- [ ] `GET /api/products/:id` still works correctly for valid numeric product IDs

🤖 Generated with [Claude Code](https://claude.com/claude-code)