### PR TITLE
feat: standardize currency formatting using fmt()

### DIFF
--- a/client/src/pages/AdminReports.jsx
+++ b/client/src/pages/AdminReports.jsx
@@ -1,5 +1,6 @@
 // src/pages/AdminReports.jsx
 import { useState, useEffect } from "react";
+import { fmt } from "../utils/formatters";
 
 const API_BASE = `${import.meta.env.VITE_API_URL}/api`;
 
@@ -84,7 +85,7 @@ export default function AdminReports() {
           <div className="bg-white rounded-2xl border border-stone-200 p-6 hover:shadow-sm transition-shadow">
             <p className="text-stone-400 text-xs uppercase tracking-wider mb-3">Total Revenue</p>
             <p className="text-3xl font-bold text-stone-800">
-              ₹{summary.totalRevenue.toLocaleString()}
+              {fmt(summary.totalRevenue)}
             </p>
           </div>
           <div className="bg-white rounded-2xl border border-stone-200 p-6 hover:shadow-sm transition-shadow">
@@ -94,7 +95,7 @@ export default function AdminReports() {
           <div className="bg-white rounded-2xl border border-stone-200 p-6 hover:shadow-sm transition-shadow">
             <p className="text-stone-400 text-xs uppercase tracking-wider mb-3">Avg Order Value</p>
             <p className="text-3xl font-bold text-stone-800">
-              ₹{summary.avgOrderValue.toLocaleString()}
+              {fmt(summary.avgOrderValue)}
             </p>
           </div>
         </div>
@@ -130,7 +131,7 @@ export default function AdminReports() {
                         </span>
                       </td>
                       <td className="px-6 py-4 text-right font-semibold text-stone-800">
-                        ₹{row.totalRevenue.toLocaleString()}
+                        {fmt(row.totalRevenue)}
                       </td>
                     </tr>
                   ))}
@@ -174,7 +175,7 @@ export default function AdminReports() {
                       </td>
                       <td className="px-6 py-4 text-center text-stone-600 font-medium">{p.totalQuantitySold}</td>
                       <td className="px-6 py-4 text-right font-semibold text-stone-800">
-                        ₹{p.totalRevenue.toLocaleString()}
+                        {fmt(p.totalRevenue)}
                       </td>
                     </tr>
                   ))}

--- a/client/src/pages/Checkout.jsx
+++ b/client/src/pages/Checkout.jsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { auth } from "../auth/firebase";          // ← Firebase auth instance
 import { onAuthStateChanged } from "firebase/auth";
+import { fmt } from "../utils/formatters";
 
 const API = import.meta.env.VITE_API_URL || "http://localhost:5000";
 
@@ -133,11 +134,11 @@ export default function Checkout() {
                     style={{ fontFamily: "'DM Serif Display', serif" }}
                     className="text-2xl text-stone-900"
                   >
-                    ₹{(product.price * quantity).toLocaleString("en-IN")}
+                    {fmt(product.price * quantity)}
                   </p>
                   {product.originalPrice > product.price && (
                     <p className="text-xs text-stone-400 line-through">
-                      ₹{(product.originalPrice * quantity).toLocaleString("en-IN")}
+                      {fmt(product.originalPrice * quantity)}
                     </p>
                   )}
                 </div>
@@ -154,7 +155,7 @@ export default function Checkout() {
               <div className="space-y-3 mb-6">
                 <div className="flex justify-between text-sm text-stone-300">
                   <span>Subtotal ({items.length} item{items.length > 1 ? "s" : ""})</span>
-                  <span>₹{subtotal.toLocaleString("en-IN")}</span>
+                  <span>{fmt(subtotal)}</span>
                 </div>
                 <div className="flex justify-between text-sm text-stone-300">
                   <span>Shipping</span>
@@ -167,7 +168,7 @@ export default function Checkout() {
                     style={{ fontFamily: "'DM Serif Display', serif" }}
                     className="text-3xl text-white"
                   >
-                    ₹{subtotal.toLocaleString("en-IN")}
+                    {fmt(subtotal)}
                   </span>
                 </div>
               </div>

--- a/client/src/pages/HomePage.jsx
+++ b/client/src/pages/HomePage.jsx
@@ -509,8 +509,8 @@ export default function HomePage() {
           </div>
           <div className="grid md:grid-cols-2 gap-5">
             {[
-              { tier: "Pro", price: "₹499/mo", desc: "Personalized nutrition plans + 5% flat discount on everything.", cta: "Upgrade to Pro" },
-              { tier: "Elite", price: "₹1,499/mo", desc: "1-on-1 coaching, early access to limited equipment drops, biometric sync.", cta: "Upgrade to Elite" },
+              { tier: "Pro", price: `${fmt(499)}/mo`, desc: "Personalized nutrition plans + 5% flat discount on everything.", cta: "Upgrade to Pro" },
+              { tier: "Elite", price: `${fmt(1499)}/mo`, desc: "1-on-1 coaching, early access to limited equipment drops, biometric sync.", cta: "Upgrade to Elite" },
             ].map((p, i) => (
               <div key={i} className="bg-white border border-stone-200 rounded-2xl p-7 flex
                                       flex-col md:flex-row md:items-center justify-between gap-5">

--- a/client/src/pages/LandingPage.jsx
+++ b/client/src/pages/LandingPage.jsx
@@ -3,6 +3,7 @@ import { useEffect, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import Navbar from "../components/Navbar";
 import { auth } from "../auth/firebase";
+import { fmt } from "../utils/formatters";
 
 // ── Static data ────────────────────────────────────────────────────────────
 const STATS = [
@@ -333,9 +334,9 @@ export default function LandingPage() {
           </div>
           <div className="grid md:grid-cols-3 gap-6 max-w-4xl mx-auto">
             {[
-              { name: "Freemium", price: "₹0", perks: ["Store access", "Public workout blogs", "Product reviews"], cta: "Start Free" },
-              { name: "Pro", price: "₹499", perks: ["Personalized nutrition plans", "5% discount on all products", "Priority support"], cta: "Go Pro", highlight: true },
-              { name: "Elite", price: "₹1,499", perks: ["1-on-1 digital coaching", "Early access to drops", "Biometric data sync"], cta: "Go Elite" },
+              { name: "Freemium", price: 0, perks: ["Store access", "Public workout blogs", "Product reviews"], cta: "Start Free" },
+              { name: "Pro", price: 499, perks: ["Personalized nutrition plans", "5% discount on all products", "Priority support"], cta: "Go Pro", highlight: true },
+              { name: "Elite", price: 1499, perks: ["1-on-1 digital coaching", "Early access to drops", "Biometric data sync"], cta: "Go Elite" },
             ].map((plan, i) => (
               <div
                 key={i}
@@ -349,9 +350,9 @@ export default function LandingPage() {
                   <p className="text-xs tracking-widest uppercase text-stone-400">{plan.name}</p>
                   <div className="flex items-baseline gap-1 mt-2">
                     <span className={`font-['DM_Serif_Display'] text-4xl ${plan.highlight ? "text-white" : "text-stone-900"}`}>
-                      {plan.price}
+                      {fmt(plan.price)}
                     </span>
-                    {plan.price !== "₹0" && (
+                    {plan.price !== 0 && (
                       <span className="text-xs text-stone-400">/mo</span>
                     )}
                   </div>

--- a/client/src/pages/PaymentPage.jsx
+++ b/client/src/pages/PaymentPage.jsx
@@ -2,6 +2,7 @@
 import { useEffect, useState } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import { auth } from "../auth/firebase";
+import { fmt } from "../utils/formatters";
 
 const API = import.meta.env.VITE_API_URL || "http://localhost:5000";
 const RAZORPAY_KEY = import.meta.env.VITE_RAZORPAY_KEY_ID;
@@ -187,7 +188,7 @@ export default function PaymentPage() {
                   <p className="text-xs text-stone-400">Qty {quantity}</p>
                 </div>
                 <p className="text-sm text-stone-900 flex-shrink-0">
-                  ₹{(product.price * quantity).toLocaleString("en-IN")}
+                  {fmt(product.price * quantity)}
                 </p>
               </div>
             ))}
@@ -199,7 +200,7 @@ export default function PaymentPage() {
               style={{ fontFamily: "'DM Serif Display', serif" }}
               className="text-3xl text-stone-900"
             >
-              ₹{total.toLocaleString("en-IN")}
+              {fmt(total)}
             </span>
           </div>
         </div>
@@ -225,7 +226,7 @@ export default function PaymentPage() {
               Opening payment…
             </>
           ) : (
-            `Pay ₹${total.toLocaleString("en-IN")} →`
+            `Pay ${fmt(total)} →`
           )}
         </button>
 

--- a/client/src/pages/ProductConfirmation.jsx
+++ b/client/src/pages/ProductConfirmation.jsx
@@ -2,6 +2,7 @@
 import { useEffect, useRef, useState } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import { auth } from "../auth/firebase";
+import { fmt } from "../utils/formatters";
 
 export default function ProductConfirmation() {
   const navigate = useNavigate();
@@ -237,10 +238,10 @@ export default function ProductConfirmation() {
           <td>
             <div class="product-brand">${product.brand || ""}</div>
             <div class="product-name">${product.name}</div>
-            <div class="unit-price">₹${product.price.toLocaleString("en-IN")} / unit</div>
+            <div class="unit-price">${fmt(product.price)} / unit</div>
           </td>
           <td style="text-align:center">${quantity}</td>
-          <td>₹${(product.price * quantity).toLocaleString("en-IN")}</td>
+          <td>${fmt(product.price * quantity)}</td>
         </tr>
       `).join("")}
     </tbody>
@@ -250,7 +251,7 @@ export default function ProductConfirmation() {
   <div class="totals">
     <div class="total-row">
       <span>Subtotal</span>
-      <span>₹${total.toLocaleString("en-IN")}</span>
+      <span>${fmt(total)}</span>
     </div>
     <div class="total-row">
       <span>Shipping</span>
@@ -262,7 +263,7 @@ export default function ProductConfirmation() {
     </div>
     <div class="total-row grand">
       <span>Total Paid</span>
-      <span>₹${total.toLocaleString("en-IN")}</span>
+      <span>${fmt(total)}</span>
     </div>
   </div>
 
@@ -383,7 +384,7 @@ export default function ProductConfirmation() {
                     <span className="text-xs text-stone-400">Qty {quantity}</span>
                     <span className="text-stone-200">·</span>
                     <span className="text-xs text-stone-400">
-                      ₹{product.price.toLocaleString("en-IN")} each
+                      {fmt(product.price)} each
                     </span>
                   </div>
                 </div>
@@ -393,7 +394,7 @@ export default function ProductConfirmation() {
                   style={{ fontFamily: "'DM Serif Display', serif" }}
                   className="text-xl text-stone-900 flex-shrink-0"
                 >
-                  ₹{(product.price * quantity).toLocaleString("en-IN")}
+                  {fmt(product.price * quantity)}
                 </p>
               </div>
             ))}
@@ -403,7 +404,7 @@ export default function ProductConfirmation() {
           <div className="bg-stone-50 border-t border-stone-200 px-7 py-5 space-y-2">
             <div className="flex justify-between text-sm text-stone-500">
               <span>Subtotal</span>
-              <span>₹{total.toLocaleString("en-IN")}</span>
+              <span>{fmt(total)}</span>
             </div>
             <div className="flex justify-between text-sm text-stone-500">
               <span>Shipping</span>
@@ -416,7 +417,7 @@ export default function ProductConfirmation() {
                 style={{ fontFamily: "'DM Serif Display', serif" }}
                 className="text-3xl text-stone-900"
               >
-                ₹{total.toLocaleString("en-IN")}
+                {fmt(total)}
               </span>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- Replaced all hard-coded `₹` concatenations and `toLocaleString("en-IN")` calls with the existing `fmt()` utility from `formatters.js`
- Updated `AdminReports.jsx`, `Checkout.jsx`, `HomePage.jsx`, `LandingPage.jsx`, `PaymentPage.jsx`, and `ProductConfirmation.jsx`
- Added `import { fmt } from "../utils/formatters"` where missing

Closes #34

## Test plan
- [ ] All currency values render consistently across all pages
- [ ] Checkout totals display correctly
- [ ] Admin reports show properly formatted revenue figures
- [ ] Product cards and payment pages use the same formatting

🤖 Generated with [Claude Code](https://claude.com/claude-code)