### PR TITLE
refactor: extract reusable useAuth hook and use it in Navbar

### DIFF
--- a/client/src/auth/useAuth.js
+++ b/client/src/auth/useAuth.js
@@ -1,0 +1,15 @@
+import { useState, useEffect } from 'react';
+import { onAuthStateChanged } from 'firebase/auth';
+import { auth } from './firebase';
+
+export function useAuth() {
+  const [user, setUser] = useState(null);
+  const [loading, setLoading] = useState(true);
+  useEffect(() => {
+    return onAuthStateChanged(auth, (u) => {
+      setUser(u);
+      setLoading(false);
+    });
+  }, []);
+  return { user, loading };
+}

--- a/client/src/components/Navbar.jsx
+++ b/client/src/components/Navbar.jsx
@@ -1,8 +1,8 @@
 // src/components/Navbar.jsx
-import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { onAuthStateChanged, signOut } from "firebase/auth";
+import { signOut } from "firebase/auth";
 import { auth } from "../auth/firebase";
+import { useAuth } from "../auth/useAuth";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Props
@@ -28,16 +28,7 @@ export default function Navbar({
   const navigate = useNavigate();
 
   // Firebase auth state — synced here so BOTH pages know if user is logged in
-  const [user, setUser] = useState(null);
-  const [authLoading, setAuthLoading] = useState(true);
-
-  useEffect(() => {
-    const unsub = onAuthStateChanged(auth, (u) => {
-      setUser(u);
-      setAuthLoading(false);
-    });
-    return () => unsub();
-  }, []);
+  const { user, loading: authLoading } = useAuth();
 
   const handleSignOut = async () => {
     if (onSignOut) {


### PR DESCRIPTION
## Summary
- Created `client/src/auth/useAuth.js` — a custom hook wrapping `onAuthStateChanged` that returns `{ user, loading }`
- Replaced the duplicated auth `useEffect` logic in `Navbar.jsx` with `useAuth()`
- Reduces duplication and makes auth state reusable across components

Closes #38

## Test plan
- [ ] Login/logout state still works correctly in the Navbar
- [ ] `useAuth()` returns correct `user` and `loading` states
- [ ] No duplicate `onAuthStateChanged` warnings in console

🤖 Generated with [Claude Code](https://claude.com/claude-code)