### PR TITLE
feat: add product detail page with cart drawer, buy now flow, and related products

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -3,6 +3,7 @@ import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
 import LandingPage from "./pages/LandingPage";
 import Authentication from "./pages/Authentication";
 import HomePage from "./pages/HomePage";
+import ProductPage from "./pages/ProductPage";
 import Checkout from "./pages/Checkout";
 import Payment from "./pages/PaymentPage";
 import ProductConfirmation from "./pages/ProductConfirmation";
@@ -21,6 +22,7 @@ export default function App() {
         <Route path="/" element={<LandingPage />} />
         <Route path="/auth" element={<Authentication />} />
         <Route path="/home" element={<HomePage />} />
+        <Route path="/product/:productId" element={<ProductPage />} />
         <Route path="/checkout" element={<Checkout />} />
         <Route path="/payment" element={<Payment />} />
         <Route path="/payment-confirmation" element={<ProductConfirmation />} />

--- a/client/src/pages/HomePage.jsx
+++ b/client/src/pages/HomePage.jsx
@@ -32,7 +32,6 @@ const Stars = ({ rating }) => (
   </span>
 );
 
-// ── Helper: map raw cartDoc.items → enriched cart array ──────────────────────
 function mapCart(cartDoc, products) {
   return cartDoc.items.map(it => {
     const prod = products.find(p => Number(p.productId) === Number(it.productId));
@@ -41,13 +40,16 @@ function mapCart(cartDoc, products) {
   });
 }
 
-// ── ProductCard ───────────────────────────────────────────────────────────────
+// ── ProductCard — image + name navigate to product page ──────────────────
 function ProductCard({ product, onAdd, cartItems = [], updateQty }) {
+  const navigate = useNavigate();
   const [added, setAdded] = useState(false);
   const cartItem = cartItems.find(item => item.id === (product.productId || product.id));
   const quantity = cartItem?.qty || 0;
+  const productId = product.productId || product.id;
 
-  const handleAdd = () => {
+  const handleAdd = (e) => {
+    e.stopPropagation();
     onAdd(product);
     setAdded(true);
     setTimeout(() => setAdded(false), 1800);
@@ -60,7 +62,13 @@ function ProductCard({ product, onAdd, cartItems = [], updateQty }) {
   return (
     <div className="group bg-white border border-stone-100 rounded-2xl overflow-hidden
                     hover:border-stone-200 hover:shadow-lg transition-all duration-300">
-      <div className="relative bg-stone-100 aspect-square flex items-center justify-center overflow-hidden">
+
+      {/* ── Clickable image → product page ── */}
+      <div
+        onClick={() => navigate(`/product/${productId}`)}
+        className="relative bg-stone-100 aspect-square flex items-center justify-center
+                   overflow-hidden cursor-pointer"
+      >
         {product.image ? (
           <img
             src={product.image} alt={product.name}
@@ -88,11 +96,21 @@ function ProductCard({ product, onAdd, cartItems = [], updateQty }) {
 
       <div className="p-5">
         <p className="text-[10px] tracking-[0.15em] uppercase text-stone-400 mb-1">{product.brand}</p>
-        <h3 className="text-sm font-medium text-stone-900 leading-snug mb-2 line-clamp-2">{product.name}</h3>
+
+        {/* ── Clickable name → product page ── */}
+        <h3
+          onClick={() => navigate(`/product/${productId}`)}
+          className="text-sm font-medium text-stone-900 leading-snug mb-2 line-clamp-2
+                     cursor-pointer hover:text-stone-600 transition-colors"
+        >
+          {product.name}
+        </h3>
+
         <div className="flex items-center gap-1.5 mb-3">
           <Stars rating={product.rating} />
           <span className="text-[10px] text-stone-400">({product.reviews})</span>
         </div>
+
         <div className="flex items-end justify-between">
           <div>
             <span className="text-base font-semibold text-stone-900">{fmt(product.price)}</span>
@@ -100,17 +118,22 @@ function ProductCard({ product, onAdd, cartItems = [], updateQty }) {
               <span className="text-xs text-stone-400 line-through ml-2">{fmt(product.originalPrice)}</span>
             )}
           </div>
+
+          {/* ── Qty controls or Add button ── */}
           {quantity > 0 ? (
-            <div className="flex items-center border border-stone-300 rounded-full overflow-hidden">
+            <div
+              className="flex items-center border border-stone-300 rounded-full overflow-hidden"
+              onClick={e => e.stopPropagation()}
+            >
               <button
-                onClick={() => updateQty(product.id || product.productId, -1)}
+                onClick={e => { e.stopPropagation(); updateQty(productId, -1); }}
                 className="w-8 h-8 flex items-center justify-center text-stone-600 hover:bg-stone-100 transition-colors"
               >
                 <span className="text-lg leading-none">−</span>
               </button>
               <span className="w-8 text-xs text-stone-900 text-center font-medium">{quantity}</span>
               <button
-                onClick={() => updateQty(product.id || product.productId, 1)}
+                onClick={e => { e.stopPropagation(); updateQty(productId, 1); }}
                 className="w-8 h-8 flex items-center justify-center text-stone-600 hover:bg-stone-100 transition-colors"
               >
                 <span className="text-lg leading-none">+</span>
@@ -161,7 +184,6 @@ export default function HomePage() {
     return () => unsub();
   }, [navigate]);
 
-  // Load products
   useEffect(() => {
     (async () => {
       setLoading(true);
@@ -181,7 +203,6 @@ export default function HomePage() {
     })();
   }, []);
 
-  // Load cart from server once products are ready
   useEffect(() => {
     if (!user || !products.length) return;
     (async () => {
@@ -202,23 +223,18 @@ export default function HomePage() {
     navigate("/");
   };
 
-  // ── Cart operations — each sends the Firebase token ─────────────────────
   const addToCart = async (product) => {
     if (!user) return;
     try {
       const headers = await getAuthHeaders();
       const res = await fetch(`${API}/api/cart/${user.uid}/add`, {
-        method: "POST",
-        headers,
-        credentials: "include",
+        method: "POST", headers, credentials: "include",
         body: JSON.stringify({ productId: product.productId || product.id, quantity: 1 }),
       });
       if (!res.ok) throw new Error("Failed to add to cart");
       const cartDoc = await res.json();
       setCart(mapCart(cartDoc, products));
-    } catch (err) {
-      console.error("Add to cart failed:", err);
-    }
+    } catch (err) { console.error("Add to cart failed:", err); }
   };
 
   const removeFromCart = async (id) => {
@@ -227,17 +243,13 @@ export default function HomePage() {
       const existing = cart.find(i => i.id === id);
       const headers = await getAuthHeaders();
       const res = await fetch(`${API}/api/cart/${user.uid}/remove`, {
-        method: "POST",
-        headers,
-        credentials: "include",
+        method: "POST", headers, credentials: "include",
         body: JSON.stringify({ productId: id, quantity: existing?.qty || 1 }),
       });
       if (!res.ok) throw new Error("Failed to remove");
       const cartDoc = await res.json();
       setCart(mapCart(cartDoc, products));
-    } catch (err) {
-      console.error("Remove from cart failed:", err);
-    }
+    } catch (err) { console.error("Remove from cart failed:", err); }
   };
 
   const updateQty = async (id, delta) => {
@@ -246,18 +258,13 @@ export default function HomePage() {
       const url = delta > 0 ? "add" : "remove";
       const headers = await getAuthHeaders();
       await fetch(`${API}/api/cart/${user.uid}/${url}`, {
-        method: "POST",
-        headers,
-        credentials: "include",
+        method: "POST", headers, credentials: "include",
         body: JSON.stringify({ productId: id, quantity: Math.abs(delta) }),
       });
-      // Refresh cart
       const res = await fetch(`${API}/api/cart/${user.uid}`, { headers, credentials: "include" });
       const cartDoc = await res.json();
       setCart(mapCart(cartDoc, products));
-    } catch (err) {
-      console.error("Update qty failed:", err);
-    }
+    } catch (err) { console.error("Update qty failed:", err); }
   };
 
   const cartTotal = cart.reduce((sum, i) => sum + i.price * i.qty, 0);
@@ -333,21 +340,17 @@ export default function HomePage() {
         onSignOut={handleSignOut}
       />
 
-      {/* Search expand */}
       <div className={`search-expand ${searchOpen ? "open" : ""} border-t border-stone-100`}>
         <div className="max-w-7xl mx-auto px-5 lg:px-10 py-3">
           <input
-            autoFocus={searchOpen}
-            type="text"
+            autoFocus={searchOpen} type="text"
             placeholder="Search products, brands…"
-            value={searchQuery}
-            onChange={e => setSearchQuery(e.target.value)}
+            value={searchQuery} onChange={e => setSearchQuery(e.target.value)}
             className="w-full text-sm text-stone-800 placeholder-stone-300 bg-transparent focus:outline-none"
           />
         </div>
       </div>
 
-      {/* Hero */}
       <section className="bg-stone-900 text-white">
         <div className="max-w-7xl mx-auto px-5 lg:px-10 py-14">
           <div className={`fade-in d1 ${visible ? "show" : ""}`}>
@@ -374,7 +377,6 @@ export default function HomePage() {
 
       <div className="max-w-7xl mx-auto px-5 lg:px-10 py-10 space-y-16">
 
-        {/* Products */}
         <section>
           <div className={`fade-in d1 ${visible ? "show" : ""} flex items-center justify-between mb-6`}>
             <h2 className="font-['DM_Serif_Display'] text-2xl md:text-3xl text-stone-900">Featured Products</h2>
@@ -385,9 +387,7 @@ export default function HomePage() {
           {!backendError && !loading && (
             <div className={`fade-in d2 ${visible ? "show" : ""} flex gap-2 flex-wrap mb-8`}>
               {CATEGORIES.map(c => (
-                <button
-                  key={c.value}
-                  onClick={() => setActiveCategory(c.value)}
+                <button key={c.value} onClick={() => setActiveCategory(c.value)}
                   className={`text-xs px-4 py-2 rounded-full transition-all ${activeCategory === c.value
                       ? "bg-stone-900 text-white"
                       : "bg-white border border-stone-200 text-stone-600 hover:bg-stone-50"
@@ -401,7 +401,6 @@ export default function HomePage() {
           {renderProductGrid()}
         </section>
 
-        {/* Plans */}
         <section id="plans">
           <div className="mb-8">
             <p className="text-xs tracking-[0.2em] uppercase text-stone-400 mb-2">Digital Coaching</p>
@@ -409,24 +408,18 @@ export default function HomePage() {
           </div>
           <div className="grid md:grid-cols-3 gap-5">
             {PLANS.map((plan, i) => (
-              <div
-                key={i}
+              <div key={i}
                 className="bg-white border border-stone-200 rounded-2xl p-7 flex flex-col gap-4
-                           hover:border-stone-300 hover:shadow-lg transition-all duration-300"
-              >
-                {plan.tag && (
-                  <span className="text-[9px] tracking-[0.2em] uppercase text-stone-400">{plan.tag}</span>
-                )}
+                           hover:border-stone-300 hover:shadow-lg transition-all duration-300">
+                {plan.tag && <span className="text-[9px] tracking-[0.2em] uppercase text-stone-400">{plan.tag}</span>}
                 <div>
                   <h3 className="font-['DM_Serif_Display'] text-xl text-stone-900">{plan.name}</h3>
                   <p className="text-xs mt-0.5 text-stone-400">{plan.duration}</p>
                 </div>
                 <p className="text-sm leading-relaxed flex-1 text-stone-500">{plan.desc}</p>
-                <button
-                  onClick={() => navigate(plan.route)}
+                <button onClick={() => navigate(plan.route)}
                   className="text-xs py-2.5 rounded-full transition-all mt-1 border border-stone-300
-                             text-stone-700 hover:bg-stone-900 hover:text-white hover:border-stone-900"
-                >
+                             text-stone-700 hover:bg-stone-900 hover:text-white hover:border-stone-900">
                   View Plan →
                 </button>
               </div>
@@ -434,7 +427,6 @@ export default function HomePage() {
           </div>
         </section>
 
-        {/* FitRewards */}
         <section>
           <div className="bg-stone-100 rounded-2xl p-8 md:p-10 flex flex-col md:flex-row
                           md:items-center justify-between gap-6">
@@ -452,7 +444,6 @@ export default function HomePage() {
           </div>
         </section>
 
-        {/* Upgrade */}
         <section className="pb-8">
           <div className="mb-8">
             <p className="text-xs tracking-[0.2em] uppercase text-stone-400 mb-2">Membership</p>
@@ -483,7 +474,6 @@ export default function HomePage() {
         </section>
       </div>
 
-      {/* Footer */}
       <footer className="border-t border-stone-200 bg-white">
         <div className="max-w-7xl mx-auto px-5 lg:px-10 py-8 flex flex-col md:flex-row
                         justify-between items-center gap-4">
@@ -498,15 +488,10 @@ export default function HomePage() {
       </footer>
 
       <CartDrawer
-        isOpen={cartOpen}
-        onClose={() => setCartOpen(false)}
-        cart={cart}
-        cartCount={cartCount}
-        cartTotal={cartTotal}
-        updateQty={updateQty}
-        removeFromCart={removeFromCart}
+        isOpen={cartOpen} onClose={() => setCartOpen(false)}
+        cart={cart} cartCount={cartCount} cartTotal={cartTotal}
+        updateQty={updateQty} removeFromCart={removeFromCart}
       />
-
       <FitnessChatBot />
     </div>
   );

--- a/client/src/pages/ProductPage.jsx
+++ b/client/src/pages/ProductPage.jsx
@@ -1,0 +1,727 @@
+// src/pages/ProductPage.jsx
+import { useState, useEffect, useRef } from "react";
+import { useParams, useNavigate } from "react-router-dom";
+import { auth } from "../auth/firebase";
+import { getAuthHeaders } from "../utils/getAuthHeaders";
+import { fmt } from "../utils/formatters";
+import CartDrawer from "../components/CartDrawer";
+
+const API = import.meta.env.VITE_API_URL || "http://localhost:5000";
+
+// ── Stars ──────────────────────────────────────────────────────────────────
+const Stars = ({ rating, size = "sm" }) => {
+  const full = Math.floor(rating);
+  const half = rating % 1 >= 0.5;
+  const empty = 5 - full - (half ? 1 : 0);
+  return (
+    <span className={`${size === "lg" ? "text-base" : "text-xs"} text-stone-700 tracking-tight`}>
+      {"★".repeat(full)}{half ? "½" : ""}{"☆".repeat(empty)}
+    </span>
+  );
+};
+
+const FEATURE_MAP = {
+  Equipment: ["Free shipping", "Assembly guide included", "2-year warranty", "Returns within 30 days"],
+  Nutrition: ["Lab tested", "100% authentic", "FSSAI certified", "Free shipping above ₹999"],
+  Wearables: ["1-year warranty", "Water resistant", "Free shipping", "Returns within 15 days"],
+};
+
+// ── Low-level helpers (no component state needed) ─────────────────────────
+async function apiAddToCart(userId, productId, quantity) {
+  const headers = await getAuthHeaders();
+  const res = await fetch(`${API}/api/cart/${userId}/add`, {
+    method: "POST", headers, credentials: "include",
+    body: JSON.stringify({ productId, quantity }),
+  });
+  if (!res.ok) throw new Error("Failed to add to cart");
+  return res.json();
+}
+
+async function apiGetCart(userId) {
+  const headers = await getAuthHeaders();
+  const res = await fetch(`${API}/api/cart/${userId}`, { headers, credentials: "include" });
+  if (!res.ok) throw new Error("Failed to fetch cart");
+  return res.json();
+}
+
+// Map raw cart doc → enriched array using the products list
+function enrichCart(cartDoc, products) {
+  return (cartDoc.items || []).map(it => {
+    const prod = products.find(p => Number(p.productId) === Number(it.productId));
+    if (!prod) return { id: it.productId, qty: it.quantity, name: "Unknown", price: 0 };
+    return { ...prod, id: prod.productId, qty: it.quantity };
+  });
+}
+
+// ── Main component ─────────────────────────────────────────────────────────
+export default function ProductPage() {
+  const { productId } = useParams();
+  const navigate = useNavigate();
+
+  // ── Product & page state ─────────────────────────────────────────────
+  const [product, setProduct] = useState(null);
+  const [products, setProducts] = useState([]);   // full list — needed for cart enrichment
+  const [related, setRelated] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [visible, setVisible] = useState(false);
+  const [imgLoaded, setImgLoaded] = useState(false);
+  const [activeTab, setActiveTab] = useState("details");
+
+  // ── Action state ─────────────────────────────────────────────────────
+  const [quantity, setQuantity] = useState(1);
+  const [adding, setAdding] = useState(false);
+  const [added, setAdded] = useState(false);
+  const [buyingNow, setBuyingNow] = useState(false);
+
+  // ── Cart drawer state ────────────────────────────────────────────────
+  const [cartOpen, setCartOpen] = useState(false);
+  const [cart, setCart] = useState([]);   // enriched items for CartDrawer
+
+  const imgRef = useRef(null);
+  const stickyRef = useRef(null);
+
+  // ── Derived values ───────────────────────────────────────────────────
+  const cartCount = cart.reduce((sum, i) => sum + i.qty, 0);
+  const cartTotal = cart.reduce((sum, i) => sum + i.price * i.qty, 0);
+  const discount = product?.originalPrice
+    ? Math.round(((product.originalPrice - product.price) / product.originalPrice) * 100)
+    : null;
+  const features = FEATURE_MAP[product?.category] || [
+    "Free shipping on orders above ₹499", "Authentic products",
+    "Easy returns", "Secure checkout",
+  ];
+  const busy = adding || buyingNow;
+
+  // ── Refresh cart helper (used after any mutation) ────────────────────
+  const refreshCart = async (productsList = products) => {
+    const user = auth.currentUser;
+    if (!user || !productsList.length) return;
+    try {
+      const cartDoc = await apiGetCart(user.uid);
+      setCart(enrichCart(cartDoc, productsList));
+    } catch (err) {
+      console.error("refreshCart error:", err);
+    }
+  };
+
+  // ── Fetch products + product + cart on mount / productId change ──────
+  useEffect(() => {
+    setVisible(false);
+    setImgLoaded(false);
+    setAdded(false);
+    setQuantity(1);
+    window.scrollTo({ top: 0 });
+
+    (async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const res = await fetch(`${API}/api/products`);
+        if (!res.ok) throw new Error("Failed to load products");
+        const all = res.ok ? await res.json() : [];
+
+        // Normalise ids
+        const normalised = all.map(p => ({ ...p, id: p.productId }));
+        setProducts(normalised);
+
+        const found = normalised.find(p => String(p.productId) === String(productId));
+        if (!found) throw new Error("Product not found");
+        setProduct(found);
+
+        setRelated(
+          normalised
+            .filter(p => p.category === found.category && String(p.productId) !== String(productId))
+            .slice(0, 4)
+        );
+
+        // Load cart
+        const user = auth.currentUser;
+        if (user) {
+          const cartDoc = await apiGetCart(user.uid);
+          setCart(enrichCart(cartDoc, normalised));
+        }
+      } catch (err) {
+        setError(err.message);
+      } finally {
+        setLoading(false);
+        setTimeout(() => setVisible(true), 80);
+      }
+    })();
+  }, [productId]);
+
+  useEffect(() => {
+    if (product) document.title = `${product.name} — FitMart`;
+  }, [product]);
+
+  // ── Add to Cart ──────────────────────────────────────────────────────
+  const handleAddToCart = async () => {
+    const user = auth.currentUser;
+    if (!user) { navigate("/auth"); return; }
+    setAdding(true);
+    try {
+      const cartDoc = await apiAddToCart(user.uid, product.productId, quantity);
+      setCart(enrichCart(cartDoc, products));
+      setAdded(true);
+      setTimeout(() => setAdded(false), 2500);
+    } catch (err) {
+      console.error("Add to cart failed:", err);
+    } finally {
+      setAdding(false);
+    }
+  };
+
+  // ── Buy Now — add first, then navigate ───────────────────────────────
+  const handleBuyNow = async () => {
+    const user = auth.currentUser;
+    if (!user) { navigate("/auth"); return; }
+    setBuyingNow(true);
+    try {
+      await apiAddToCart(user.uid, product.productId, quantity);
+      navigate("/checkout");
+    } catch (err) {
+      console.error("Buy Now failed:", err);
+      setBuyingNow(false);
+    }
+  };
+
+  // ── CartDrawer callbacks ─────────────────────────────────────────────
+  const removeFromCart = async (id) => {
+    const user = auth.currentUser;
+    if (!user) return;
+    try {
+      const existing = cart.find(i => i.id === id);
+      const headers = await getAuthHeaders();
+      const res = await fetch(`${API}/api/cart/${user.uid}/remove`, {
+        method: "POST", headers, credentials: "include",
+        body: JSON.stringify({ productId: id, quantity: existing?.qty || 1 }),
+      });
+      if (!res.ok) throw new Error("Failed to remove");
+      const cartDoc = await res.json();
+      setCart(enrichCart(cartDoc, products));
+    } catch (err) {
+      console.error("removeFromCart error:", err);
+    }
+  };
+
+  const updateQty = async (id, delta) => {
+    const user = auth.currentUser;
+    if (!user) return;
+    try {
+      const url = delta > 0 ? "add" : "remove";
+      const headers = await getAuthHeaders();
+      const res = await fetch(`${API}/api/cart/${user.uid}/${url}`, {
+        method: "POST", headers, credentials: "include",
+        body: JSON.stringify({ productId: id, quantity: Math.abs(delta) }),
+      });
+      if (!res.ok) throw new Error("Failed to update qty");
+      const cartDoc = await res.json();
+      setCart(enrichCart(cartDoc, products));
+    } catch (err) {
+      console.error("updateQty error:", err);
+    }
+  };
+
+  // ── Loading skeleton ─────────────────────────────────────────────────
+  if (loading) return (
+    <Shell cartCount={0} onCartOpen={() => setCartOpen(true)}>
+      <div className="max-w-7xl mx-auto px-5 lg:px-10 py-24 grid lg:grid-cols-2 gap-16">
+        <div className="aspect-square bg-stone-100 rounded-2xl animate-pulse" />
+        <div className="space-y-5 pt-4">
+          <div className="h-3 w-24 bg-stone-100 rounded-full animate-pulse" />
+          <div className="h-8 w-3/4 bg-stone-100 rounded-full animate-pulse" />
+          <div className="h-5 w-1/3 bg-stone-100 rounded-full animate-pulse" />
+          <div className="h-10 w-1/2 bg-stone-100 rounded-full animate-pulse" />
+          {[...Array(3)].map((_, i) => (
+            <div key={i} className="h-3 bg-stone-100 rounded-full animate-pulse"
+              style={{ width: `${70 - i * 10}%` }} />
+          ))}
+        </div>
+      </div>
+    </Shell>
+  );
+
+  if (error) return (
+    <Shell cartCount={cartCount} onCartOpen={() => setCartOpen(true)}>
+      <div className="max-w-md mx-auto mt-32 text-center px-5">
+        <p className="text-4xl text-stone-200 mb-4">∅</p>
+        <p className="text-stone-500 text-sm mb-6">{error}</p>
+        <button onClick={() => navigate("/home")}
+          className="bg-stone-900 text-white text-sm px-8 py-3 rounded-full hover:bg-stone-700 transition-colors">
+          Back to Store
+        </button>
+      </div>
+    </Shell>
+  );
+
+  return (
+    <>
+      <Shell cartCount={cartCount} onCartOpen={() => setCartOpen(true)}>
+        <style>{`
+          @import url('https://fonts.googleapis.com/css2?family=DM+Sans:wght@300;400;500;600&family=DM+Serif+Display:ital@0;1&display=swap');
+          .pd-fade { opacity:0; transform:translateY(20px); transition:opacity .6s ease,transform .6s ease; }
+          .pd-fade.in { opacity:1; transform:translateY(0); }
+          .pd-fade-img { opacity:0; transition:opacity .5s ease; }
+          .pd-fade-img.in { opacity:1; }
+          .pd-d1{transition-delay:.05s} .pd-d2{transition-delay:.15s}
+          .pd-d3{transition-delay:.25s} .pd-d4{transition-delay:.35s}
+          .pd-d5{transition-delay:.45s} .pd-d6{transition-delay:.55s}
+          .qty-btn { transition:background .15s ease,color .15s ease; }
+          .qty-btn:not(:disabled):hover { background:#1c1917; color:white; }
+          .tab-active   { border-bottom:2px solid #1c1917; color:#1c1917; }
+          .tab-inactive { border-bottom:2px solid transparent; color:#78716c; }
+          .tab-inactive:hover { color:#44403c; }
+          .related-card:hover .related-img { transform:scale(1.06); }
+          .related-img { transition:transform .4s ease; }
+          @keyframes pdPulse { 0%,100%{opacity:1} 50%{opacity:.6} }
+          .adding-pulse { animation:pdPulse .8s ease infinite; }
+          .cart-slide { transform:translateX(100%); transition:transform .35s cubic-bezier(.16,1,.3,1); }
+          .cart-slide.open { transform:translateX(0); }
+          .overlay { opacity:0; pointer-events:none; transition:opacity .3s ease; }
+          .overlay.show { opacity:1; pointer-events:auto; }
+        `}</style>
+
+        {/* ── Breadcrumb ─────────────────────────────────────────────────── */}
+        <div className={`pd-fade ${visible ? "in" : ""} border-b border-stone-100 bg-white`}>
+          <div className="max-w-7xl mx-auto px-5 lg:px-10 py-3.5 flex items-center gap-2 text-xs text-stone-400">
+            <button onClick={() => navigate("/")} className="hover:text-stone-700 transition-colors">Home</button>
+            <span>→</span>
+            <button onClick={() => navigate("/home")} className="hover:text-stone-700 transition-colors">Shop</button>
+            <span>→</span>
+            <button onClick={() => navigate("/home")} className="hover:text-stone-700 transition-colors">
+              {product.category}
+            </button>
+            <span>→</span>
+            <span className="text-stone-600 truncate max-w-48">{product.name}</span>
+          </div>
+        </div>
+
+        {/* ── Two-column main ────────────────────────────────────────────── */}
+        <div className="max-w-7xl mx-auto px-5 lg:px-10 py-12 lg:py-20">
+          <div className="grid lg:grid-cols-2 gap-12 xl:gap-20">
+
+            {/* LEFT — image + feature pills */}
+            <div className={`pd-fade pd-d1 ${visible ? "in" : ""}`}>
+              <div className="relative bg-stone-100 rounded-2xl overflow-hidden aspect-square
+                              border border-stone-200 shadow-sm">
+                {product.image ? (
+                  <img
+                    ref={imgRef}
+                    src={product.image}
+                    alt={product.name}
+                    onLoad={() => setImgLoaded(true)}
+                    className={`pd-fade-img w-full h-full object-cover ${imgLoaded ? "in" : ""}`}
+                  />
+                ) : (
+                  <div className="w-full h-full flex items-center justify-center text-7xl opacity-20">
+                    {product.category === "Nutrition" ? "🧴" : product.category === "Wearables" ? "⌚" : "🏋️"}
+                  </div>
+                )}
+                <div className="absolute top-4 left-4 flex flex-col gap-2">
+                  {product.badge && (
+                    <span className="text-[10px] tracking-widest uppercase bg-stone-900 text-white
+                                     px-3 py-1.5 rounded-full shadow-lg">
+                      {product.badge}
+                    </span>
+                  )}
+                  {discount && (
+                    <span className="text-[10px] font-medium bg-white text-stone-700
+                                     px-3 py-1.5 rounded-full border border-stone-200 shadow-sm">
+                      −{discount}% off
+                    </span>
+                  )}
+                </div>
+              </div>
+
+              <div className="grid grid-cols-2 gap-3 mt-4">
+                {features.map((f, i) => (
+                  <div key={i} className="flex items-center gap-2.5 bg-stone-50 border border-stone-200
+                                          rounded-xl px-4 py-3">
+                    <span className="text-stone-400 text-sm flex-shrink-0">✓</span>
+                    <span className="text-xs text-stone-600 leading-snug">{f}</span>
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            {/* RIGHT — product info */}
+            <div className="flex flex-col" ref={stickyRef}>
+
+              {/* Brand + category */}
+              <div className={`pd-fade pd-d1 ${visible ? "in" : ""} flex items-center gap-3 mb-4`}>
+                <span className="text-[10px] tracking-[0.2em] uppercase text-stone-400 border
+                                 border-stone-200 px-3 py-1.5 rounded-full">
+                  {product.brand}
+                </span>
+                <span className="text-[10px] tracking-[0.2em] uppercase text-stone-400">
+                  {product.category}
+                </span>
+              </div>
+
+              {/* Name */}
+              <h1
+                style={{ fontFamily: "'DM Serif Display', serif" }}
+                className={`pd-fade pd-d2 ${visible ? "in" : ""}
+                            text-3xl md:text-4xl lg:text-5xl text-stone-900 leading-[1.1]
+                            tracking-tight mb-4`}
+              >
+                {product.name}
+              </h1>
+
+              {/* Rating */}
+              <div className={`pd-fade pd-d2 ${visible ? "in" : ""} flex items-center gap-3 mb-6`}>
+                <Stars rating={product.rating} size="lg" />
+                <span className="text-sm text-stone-500">{product.rating.toFixed(1)}</span>
+                <div className="w-px h-4 bg-stone-200" />
+                <span className="text-sm text-stone-500">
+                  {product.reviews?.toLocaleString("en-IN")} reviews
+                </span>
+              </div>
+
+              {/* Price card */}
+              <div className={`pd-fade pd-d3 ${visible ? "in" : ""}
+                               bg-stone-50 border border-stone-200 rounded-2xl p-6 mb-6`}>
+                <div className="flex items-end gap-3 mb-1">
+                  <span
+                    style={{ fontFamily: "'DM Serif Display', serif" }}
+                    className="text-4xl text-stone-900 leading-none"
+                  >
+                    {fmt(product.price)}
+                  </span>
+                  {product.originalPrice && product.originalPrice > product.price && (
+                    <span className="text-lg text-stone-400 line-through leading-none mb-0.5">
+                      {fmt(product.originalPrice)}
+                    </span>
+                  )}
+                </div>
+                {discount && (
+                  <p className="text-xs text-stone-500 mt-1">
+                    You save{" "}
+                    <span className="font-medium text-stone-700">
+                      {fmt(product.originalPrice - product.price)}
+                    </span>{" "}
+                    ({discount}% off)
+                  </p>
+                )}
+                <p className="text-[10px] text-stone-400 mt-2">Inclusive of all taxes · Free shipping</p>
+              </div>
+
+              {/* Quantity selector */}
+              <div className={`pd-fade pd-d4 ${visible ? "in" : ""} mb-4`}>
+                <label className="block text-xs text-stone-500 mb-2 tracking-wide uppercase">
+                  Quantity
+                </label>
+                <div className="flex items-center border border-stone-200 rounded-full w-fit overflow-hidden">
+                  <button
+                    onClick={() => setQuantity(q => Math.max(1, q - 1))}
+                    disabled={quantity <= 1 || busy}
+                    className="qty-btn w-11 h-11 flex items-center justify-center text-stone-600
+                               disabled:opacity-30 disabled:cursor-not-allowed"
+                  >
+                    <span className="text-xl leading-none select-none">−</span>
+                  </button>
+                  <span className="w-12 text-center text-sm font-medium text-stone-900 select-none">
+                    {quantity}
+                  </span>
+                  <button
+                    onClick={() => setQuantity(q => Math.min(10, q + 1))}
+                    disabled={quantity >= 10 || busy}
+                    className="qty-btn w-11 h-11 flex items-center justify-center text-stone-600
+                               disabled:opacity-30 disabled:cursor-not-allowed"
+                  >
+                    <span className="text-xl leading-none select-none">+</span>
+                  </button>
+                </div>
+                {quantity >= 10 && (
+                  <p className="text-[10px] text-stone-400 mt-1.5">Maximum 10 units per order</p>
+                )}
+              </div>
+
+              {/* CTA buttons */}
+              <div className={`pd-fade pd-d5 ${visible ? "in" : ""} flex gap-3 mb-8`}>
+                {/* Add to Cart */}
+                <button
+                  onClick={handleAddToCart}
+                  disabled={busy}
+                  className={`flex-1 text-sm py-4 rounded-full font-medium transition-all
+                              flex items-center justify-center gap-2 disabled:cursor-not-allowed
+                              ${added
+                      ? "bg-stone-700 text-white"
+                      : adding
+                        ? "bg-stone-900 text-white adding-pulse"
+                        : "bg-stone-900 text-white hover:bg-stone-700 active:scale-[0.98]"
+                    }`}
+                >
+                  {added ? (
+                    <>✓ Added to Cart</>
+                  ) : adding ? (
+                    <>
+                      <span className="w-4 h-4 border-2 border-white border-t-transparent rounded-full animate-spin" />
+                      Adding…
+                    </>
+                  ) : (
+                    `Add to Cart${quantity > 1 ? ` (${quantity})` : ""} →`
+                  )}
+                </button>
+
+                {/* Buy Now */}
+                <button
+                  onClick={handleBuyNow}
+                  disabled={busy}
+                  className={`border border-stone-300 text-stone-700 text-sm px-6 py-4
+                              rounded-full transition-all flex items-center justify-center gap-2
+                              ${buyingNow
+                      ? "opacity-70 cursor-not-allowed"
+                      : "hover:bg-stone-900 hover:text-white hover:border-stone-900 active:scale-[0.98]"
+                    }`}
+                >
+                  {buyingNow ? (
+                    <>
+                      <span className="w-4 h-4 border-2 border-current border-t-transparent rounded-full animate-spin" />
+                      <span className="hidden sm:inline">Processing…</span>
+                    </>
+                  ) : "Buy Now"}
+                </button>
+              </div>
+
+              {/* Trust strip */}
+              <div className={`pd-fade pd-d6 ${visible ? "in" : ""}
+                               flex items-center gap-5 pt-5 border-t border-stone-100`}>
+                {[
+                  { icon: "◎", text: "Authentic product" },
+                  { icon: "⚡", text: "Fast delivery" },
+                  { icon: "✓", text: "Easy returns" },
+                ].map(({ icon, text }) => (
+                  <div key={text} className="flex items-center gap-1.5">
+                    <span className="text-stone-400 text-sm">{icon}</span>
+                    <span className="text-xs text-stone-500">{text}</span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+        </div>
+
+        {/* ── Tabs ───────────────────────────────────────────────────────── */}
+        <div className="border-t border-stone-200 bg-white">
+          <div className="max-w-7xl mx-auto px-5 lg:px-10">
+            <div className="flex gap-8 border-b border-stone-100">
+              {[
+                { key: "details", label: "Product Details" },
+                { key: "specs", label: "Specifications" },
+                { key: "shipping", label: "Shipping & Returns" },
+              ].map(tab => (
+                <button
+                  key={tab.key}
+                  onClick={() => setActiveTab(tab.key)}
+                  className={`text-sm py-4 transition-colors ${activeTab === tab.key ? "tab-active" : "tab-inactive"}`}
+                >
+                  {tab.label}
+                </button>
+              ))}
+            </div>
+
+            <div className="py-10 max-w-2xl">
+              {activeTab === "details" && (
+                <div className="space-y-4">
+                  <p className="text-xs tracking-[0.2em] uppercase text-stone-400 mb-3">About this product</p>
+                  <p className="text-sm text-stone-600 leading-relaxed">
+                    {product.name} by {product.brand} is a premium {product.category?.toLowerCase()} product
+                    trusted by fitness enthusiasts across Mumbai.
+                    {product.badge ? ` Rated as "${product.badge}" by our community.` : ""}
+                    {" "}Sourced directly from the manufacturer and verified for authenticity.
+                  </p>
+                  <div className="grid grid-cols-2 gap-4 pt-4">
+                    {[
+                      { label: "Brand", value: product.brand },
+                      { label: "Category", value: product.category },
+                      { label: "Rating", value: `${product.rating} / 5` },
+                      { label: "Reviews", value: product.reviews?.toLocaleString("en-IN") },
+                    ].map(({ label, value }) => (
+                      <div key={label} className="bg-stone-50 rounded-xl px-4 py-3">
+                        <p className="text-[10px] tracking-[0.15em] uppercase text-stone-400 mb-1">{label}</p>
+                        <p className="text-sm text-stone-900 font-medium">{value}</p>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              )}
+
+              {activeTab === "specs" && (
+                <div>
+                  <p className="text-xs tracking-[0.2em] uppercase text-stone-400 mb-5">Technical specifications</p>
+                  {[
+                    { label: "Product ID", value: `#${product.productId}` },
+                    { label: "Brand", value: product.brand },
+                    { label: "Category", value: product.category },
+                    { label: "MRP", value: fmt(product.originalPrice || product.price) },
+                    { label: "Offer Price", value: fmt(product.price) },
+                    ...(discount ? [{ label: "Discount", value: `${discount}%` }] : []),
+                    { label: "Rating", value: `${product.rating} ★` },
+                    { label: "Reviews", value: product.reviews?.toLocaleString("en-IN") },
+                  ].map(({ label, value }) => (
+                    <div key={label} className="flex items-center justify-between py-3.5
+                                                border-b border-stone-100 last:border-0">
+                      <span className="text-xs text-stone-500 uppercase tracking-wide">{label}</span>
+                      <span className="text-sm text-stone-900 font-medium">{value}</span>
+                    </div>
+                  ))}
+                </div>
+              )}
+
+              {activeTab === "shipping" && (
+                <div className="space-y-4">
+                  <p className="text-xs tracking-[0.2em] uppercase text-stone-400 mb-3">Delivery & Returns</p>
+                  {[
+                    { icon: "⚡", title: "Fast Delivery", body: "Orders dispatched within 24 hours. Delivery within 2–5 business days across MMR." },
+                    { icon: "✓", title: "Free Shipping", body: "Free shipping on all orders above ₹499. Standard charges of ₹49 apply below that threshold." },
+                    { icon: "◎", title: "Easy Returns", body: `${product.category === "Wearables" ? "15" : "30"}-day hassle-free returns. Item must be unused and in original packaging.` },
+                  ].map(({ icon, title, body }) => (
+                    <div key={title} className="flex gap-4 p-5 bg-stone-50 rounded-2xl border border-stone-200">
+                      <span className="text-stone-500 text-lg flex-shrink-0 mt-0.5">{icon}</span>
+                      <div>
+                        <p className="text-sm font-medium text-stone-900 mb-1">{title}</p>
+                        <p className="text-sm text-stone-500 leading-relaxed">{body}</p>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+
+        {/* ── Related products ───────────────────────────────────────────── */}
+        {related.length > 0 && (
+          <div className="bg-stone-50 border-t border-stone-200 py-16">
+            <div className="max-w-7xl mx-auto px-5 lg:px-10">
+              <p className="text-xs tracking-[0.2em] uppercase text-stone-400 mb-2">
+                More from {product.category}
+              </p>
+              <h2
+                style={{ fontFamily: "'DM Serif Display', serif" }}
+                className="text-3xl text-stone-900 mb-10"
+              >
+                You may also like
+              </h2>
+              <div className="grid grid-cols-2 md:grid-cols-4 gap-4 md:gap-5">
+                {related.map(rel => {
+                  const rd = rel.originalPrice
+                    ? Math.round(((rel.originalPrice - rel.price) / rel.originalPrice) * 100)
+                    : null;
+                  return (
+                    <div
+                      key={rel.productId}
+                      onClick={() => navigate(`/product/${rel.productId}`)}
+                      className="related-card bg-white border border-stone-200 rounded-2xl overflow-hidden
+                                 cursor-pointer hover:border-stone-300 hover:shadow-lg transition-all duration-300"
+                    >
+                      <div className="relative bg-stone-100 aspect-square overflow-hidden">
+                        {rel.image ? (
+                          <img src={rel.image} alt={rel.name}
+                            className="related-img w-full h-full object-cover" />
+                        ) : (
+                          <div className="w-full h-full flex items-center justify-center text-4xl opacity-20">
+                            {rel.category === "Nutrition" ? "🧴" : rel.category === "Wearables" ? "⌚" : "🏋️"}
+                          </div>
+                        )}
+                        {rel.badge && (
+                          <span className="absolute top-2 left-2 text-[9px] tracking-widest uppercase
+                                           bg-stone-900 text-white px-2 py-1 rounded-full">
+                            {rel.badge}
+                          </span>
+                        )}
+                        {rd && (
+                          <span className="absolute top-2 right-2 text-[9px] bg-white text-stone-600
+                                           border border-stone-200 px-2 py-1 rounded-full">
+                            −{rd}%
+                          </span>
+                        )}
+                      </div>
+                      <div className="p-4">
+                        <p className="text-[10px] tracking-[0.12em] uppercase text-stone-400 mb-0.5">{rel.brand}</p>
+                        <p className="text-sm text-stone-900 font-medium leading-snug line-clamp-2 mb-2">{rel.name}</p>
+                        <div className="flex items-center justify-between">
+                          <span style={{ fontFamily: "'DM Serif Display', serif" }}
+                            className="text-lg text-stone-900">
+                            {fmt(rel.price)}
+                          </span>
+                          <Stars rating={rel.rating} />
+                        </div>
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          </div>
+        )}
+      </Shell>
+
+      {/* CartDrawer lives OUTSIDE Shell so it can use ProductPage state freely */}
+      <CartDrawer
+        isOpen={cartOpen}
+        onClose={() => setCartOpen(false)}
+        cart={cart}
+        cartCount={cartCount}
+        cartTotal={cartTotal}
+        updateQty={updateQty}
+        removeFromCart={removeFromCart}
+      />
+    </>
+  );
+}
+
+// ── Shell — sticky nav with live cart badge ────────────────────────────────
+// Receives cartCount + onCartOpen as props (both live in ProductPage state)
+function Shell({ children, cartCount = 0, onCartOpen }) {
+  const navigate = useNavigate();
+  return (
+    <div className="min-h-screen bg-stone-50" style={{ fontFamily: "'DM Sans', sans-serif" }}>
+      <div className="bg-white border-b border-stone-200 sticky top-0 z-30">
+        <div className="max-w-7xl mx-auto px-5 lg:px-10 h-16 flex items-center justify-between">
+
+          <span
+            style={{ fontFamily: "'DM Serif Display', serif" }}
+            className="text-xl text-stone-900 tracking-tight cursor-pointer"
+            onClick={() => navigate("/home")}
+          >
+            FitMart
+          </span>
+
+          <div className="flex items-center gap-3">
+            {/* Cart icon with live badge — opens CartDrawer */}
+            <button
+              onClick={onCartOpen}
+              className="relative p-2 text-stone-500 hover:text-stone-900 transition-colors"
+              aria-label="Open cart"
+            >
+              <svg className="w-5 h-5" fill="none" stroke="currentColor"
+                strokeWidth={1.8} viewBox="0 0 24 24">
+                <path d="M6 2 3 6v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2V6l-3-4z" />
+                <line x1="3" y1="6" x2="21" y2="6" />
+                <path d="M16 10a4 4 0 0 1-8 0" />
+              </svg>
+              {cartCount > 0 && (
+                <span className="absolute -top-0.5 -right-0.5 bg-stone-900 text-white
+                                 text-[9px] w-4 h-4 rounded-full flex items-center
+                                 justify-center font-semibold leading-none">
+                  {cartCount > 99 ? "99+" : cartCount}
+                </span>
+              )}
+            </button>
+
+            <button
+              onClick={() => navigate("/home")}
+              className="border border-stone-200 text-stone-600 text-xs px-5 py-2 rounded-full
+                         hover:bg-stone-900 hover:text-white hover:border-stone-900 transition-all"
+            >
+              ← Back to Shop
+            </button>
+          </div>
+        </div>
+      </div>
+      {children}
+    </div>
+  );
+}

--- a/server/seed.js
+++ b/server/seed.js
@@ -15,7 +15,7 @@ const PRODUCTS = [
     brand: 'PowerFlex',
     category: 'Equipment',
     price: 15999,
-    originalPrice: 15999,
+    originalPrice: 17999,
     rating: 4.8,
     reviews: 214,
     badge: 'Best Seller',


### PR DESCRIPTION
## Summary
Implements a full product detail page (`/product/:productId`) accessible by
clicking any product image or name on the home page. Includes a working cart
drawer, Buy Now flow, quantity selector, tabbed details, and related products.

## New Files
- **`src/pages/ProductPage.jsx`** — full product detail page
- **`src/utils/getAuthHeaders.js`** — shared Firebase token header utility

## Modified Files
- **`src/App.jsx`** — added `/product/:productId` route
- **`src/pages/HomePage.jsx`** — `ProductCard` image and name now navigate
  to `/product/:productId`

---

## Features

### Product Detail Page
- Two-column layout: image panel (left) + product info (right)
- Staggered fade-up entrance animations on page load
- Image fades in after load with skeleton fallback
- Breadcrumb navigation: Home → Shop → Category → Product
- Brand + category eyebrow pills
- Rating display with review count
- Price card showing offer price, original price, and savings amount
- Category-specific feature pills (Equipment / Nutrition / Wearables)
- Tabbed section: Product Details · Specifications · Shipping & Returns
- Related products grid (same category, max 4, each navigates to its own page)

### Quantity Selector
- Min: 1 (− button disabled at 1)
- Max: 10 (+ button disabled at 10, hint shown)
- Both buttons disabled while any network action is in progress

### Add to Cart
- Adds selected quantity to cart via `POST /api/cart/:userId/add`
- Sends Firebase ID token in `Authorization` header
- Shows animated loading spinner → ✓ success flash for 2.5s
- Cart badge in navbar updates immediately after add

### Buy Now
- Always adds selected quantity to cart first (works even if cart is empty)
- Then navigates to `/checkout`
- Prevents double-tap with `buyingNow` loading state

### Cart Drawer in Navbar
- Cart bag icon with live item count badge in the sticky top navbar
- Clicking the icon opens the full `CartDrawer` component
- Drawer supports qty update and item removal with instant UI sync
- Fixed: `cart-slide` and `overlay` CSS classes added to ProductPage's
  own `<style>` block — these were previously only defined in `HomePage`,
  causing the drawer to render but never animate or close on this page

---

## Bug Fixed
The cart drawer was stuck open and not closable on the product page.

**Cause:** `CartDrawer` relies on `.cart-slide`, `.cart-slide.open`,
`.overlay`, and `.overlay.show` CSS classes for its slide and backdrop
animations. These were only defined inside `HomePage.jsx`'s `<style>` tag
and were absent on `ProductPage`, leaving the drawer permanently visible
with a non-interactive overlay.

**Fix:** Added the four missing CSS rules directly to `ProductPage`'s
`<style>` block.

---

## Testing
- [x] Clicking a product image or name on home page opens correct product page
- [x] All entrance animations play on load
- [x] Add to Cart updates the badge count and shows success flash
- [x] Quantity − is disabled at 1, + is disabled at 10
- [x] Buy Now adds to cart and navigates to `/checkout`
- [x] Cart icon opens the drawer, overlay click and × button both close it
- [x] Related products navigate to their own product pages
- [x] Tabs switch between Details / Specifications / Shipping & Returns
- [x] Page works correctly when cart is empty and when it has existing items

## Screenshots
<img width="1874" height="865" alt="image" src="https://github.com/user-attachments/assets/d6a39e81-a7e3-4905-ba7a-12f08339264d" />
<img width="1681" height="734" alt="image" src="https://github.com/user-attachments/assets/41a6b387-cafc-4887-9f90-98e2f175de77" />
