### PR TITLE
feat(firebase): centralize Firebase Admin initialization and remove duplicate setups

### DIFF
--- a/server/firebaseAdmin.js
+++ b/server/firebaseAdmin.js
@@ -1,0 +1,33 @@
+// server/firebaseAdmin.js
+const admin = require('firebase-admin');
+
+if (!admin.apps.length) {
+  const projectId = process.env.FIREBASE_PROJECT_ID;
+  const clientEmail = process.env.FIREBASE_CLIENT_EMAIL;
+  const privateKey = process.env.FIREBASE_PRIVATE_KEY
+    ? process.env.FIREBASE_PRIVATE_KEY.replace(/\\n/g, '\n')
+    : undefined;
+
+  if (projectId && clientEmail && privateKey) {
+    admin.initializeApp({
+      credential: admin.credential.cert({
+        projectId,
+        clientEmail,
+        privateKey,
+      }),
+    });
+    console.log('Firebase Admin initialized from environment variables');
+  } else if (process.env.GOOGLE_APPLICATION_CREDENTIALS) {
+    // fall back to Application Default Credentials (file referenced by env var)
+    admin.initializeApp({
+      credential: admin.credential.applicationDefault(),
+    });
+    console.log('Firebase Admin initialized using application default credentials');
+  } else {
+    console.warn(
+      'Firebase Admin not initialized: missing credentials. Set FIREBASE_PROJECT_ID, FIREBASE_CLIENT_EMAIL, and FIREBASE_PRIVATE_KEY in environment.'
+    );
+  }
+}
+
+module.exports = admin;

--- a/server/middleware/verifyFirebaseToken.js
+++ b/server/middleware/verifyFirebaseToken.js
@@ -1,16 +1,5 @@
 // server/middleware/verifyFirebaseToken.js
-const admin = require('firebase-admin');
-
-// Initialize Firebase Admin only once
-if (!admin.apps.length) {
-  admin.initializeApp({
-    credential: admin.credential.cert({
-      projectId: process.env.FIREBASE_PROJECT_ID,
-      clientEmail: process.env.FIREBASE_CLIENT_EMAIL,
-      privateKey: process.env.FIREBASE_PRIVATE_KEY?.replace(/\\n/g, '\n'),
-    }),
-  });
-}
+const admin = require('../firebaseAdmin');
 
 const verifyFirebaseToken = async (req, res, next) => {
   const authHeader = req.headers.authorization;

--- a/server/routes/customers.js
+++ b/server/routes/customers.js
@@ -2,20 +2,7 @@
 const express = require('express');
 const router = express.Router();
 const Order = require('../models/Order');
-const admin = require('firebase-admin');
-
-// ── Initialize Firebase Admin once ────────────────────────────────────────
-// Uses the same explicit env vars as the rest of your server
-if (!admin.apps.length) {
-  admin.initializeApp({
-    credential: admin.credential.cert({
-      projectId: process.env.FIREBASE_PROJECT_ID,
-      clientEmail: process.env.FIREBASE_CLIENT_EMAIL,
-      // .env stores the private key with literal \n — replace to real newlines
-      privateKey: process.env.FIREBASE_PRIVATE_KEY?.replace(/\\n/g, '\n'),
-    }),
-  });
-}
+const admin = require('../firebaseAdmin');
 
 // ── Helper: resolve Firebase UID → { displayName, email, photoURL } ───────
 async function resolveFirebaseUser(uid) {

--- a/server/routes/dashboard.js
+++ b/server/routes/dashboard.js
@@ -3,16 +3,7 @@ const express = require('express');
 const router = express.Router();
 const Order = require('../models/Order');
 const Product = require('../models/Product');
-const admin = require('firebase-admin');
-
-// ── Initialize Firebase Admin once ────────────────────────────────────────
-// Reads credentials from GOOGLE_APPLICATION_CREDENTIALS env var
-// which points to your serviceAccountKey.json file
-if (!admin.apps.length) {
-  admin.initializeApp({
-    credential: admin.credential.applicationDefault(),
-  });
-}
+const admin = require('../firebaseAdmin');
 
 // ── Helper: resolve Firebase UID → { displayName, email } ─────────────────
 // Returns "—" gracefully if user is deleted or UID is invalid


### PR DESCRIPTION
This PR refactors Firebase Admin initialization across the server by centralizing it into a single module (`firebaseAdmin.js`) and removing redundant initialization logic from multiple files.

### **Key Changes**

* ✅ Created a dedicated `firebaseAdmin.js` to handle Firebase Admin setup
* ✅ Added support for:

  * Environment variable-based credentials (`FIREBASE_PROJECT_ID`, `FIREBASE_CLIENT_EMAIL`, `FIREBASE_PRIVATE_KEY`)
  * Fallback to `GOOGLE_APPLICATION_CREDENTIALS`
* ✅ Replaced direct `firebase-admin` imports with the centralized module in:

  * `verifyFirebaseToken.js`
  * `customers.js`
  * `dashboard.js`
* ✅ Removed duplicate and repeated initialization logic across files

### **Why This Change?**

* Avoids multiple Firebase app initializations
* Improves maintainability and scalability
* Ensures consistent credential handling across the backend
* Makes the codebase cleaner and easier to debug

### **Notes**

* Logs are added to indicate which initialization method is used
* Warning is shown if required credentials are missing