### PR TITLE
fix(landing-page): improve community attribution text clarity

### DIFF
--- a/client/src/pages/LandingPage.jsx
+++ b/client/src/pages/LandingPage.jsx
@@ -231,7 +231,7 @@ export default function LandingPage() {
             <div className={`fade-up ${visible ? "visible" : ""} delay-5 mt-6`}>
               <p className="text-xs text-stone-400 flex items-center gap-1.5 flex-wrap">
                 <GithubIcon className="w-3.5 h-3.5" />
-                Open-source · Built by the{" "}
+                Open-source · Built by{" "}
                 <a
                   href={INSTAGRAM}
                   target="_blank"
@@ -239,9 +239,9 @@ export default function LandingPage() {
                   className="underline underline-offset-2 decoration-stone-300 hover:text-stone-700
                   transition-colors"
                 >
-                  parth.builds
+                  parth.builds community
                 </a>
-                {" "}community · 20 contributors · 21 forks
+                {" "}
               </p>
             </div>
           </div>


### PR DESCRIPTION
## Overview
This PR improves the clarity of the open-source community attribution text on the landing page.

## Changes Made
- Changed "Built by the parth.builds community" to "Built by parth.builds community" for better readability
- Removed extra space and unnecessary word "the" from the attribution text
- Consolidated community reference to flow more naturally

## Before
```
Open-source · Built by the parth.builds community · 20 contributors · 21 forks
```

## After
```
Open-source · Built by parth.builds community
```

## Files Changed
- `client/src/pages/LandingPage.jsx` - Updated community attribution text

## Impact
- Minor text improvement, no functional changes
- Better grammatical flow for the community credit line